### PR TITLE
Restraints

### DIFF
--- a/bin/simulation/lightdock_setup.py
+++ b/bin/simulation/lightdock_setup.py
@@ -65,6 +65,7 @@ if __name__ == "__main__":
             calculate_anm(ligand, args.anm_lig, DEFAULT_LIG_NM_FILE)
 
         # Parse restraints if any:
+        receptor_restraints = ligand_restraints = None
         if args.restraints:
             log.info("Reading restraints from %s" % args.restraints)
             restraints = parse_restraints_file(args.restraints)

--- a/bin/simulation/lightdock_setup.py
+++ b/bin/simulation/lightdock_setup.py
@@ -13,7 +13,8 @@ import numpy as np
 from lightdock.util.parser import SetupCommandLineParser
 from lightdock.prep.simulation import read_input_structure, save_lightdock_structure, \
                                       calculate_starting_positions, prepare_results_environment, \
-                                      create_setup_file, calculate_anm
+                                      create_setup_file, calculate_anm, parse_restraints_file, \
+                                      get_restraints
 from lightdock.constants import DEFAULT_LIGHTDOCK_PREFIX, DEFAULT_ELLIPSOID_DATA_EXTENSION, \
                                 DEFAULT_NMODES_REC, DEFAULT_REC_NM_FILE, DEFAULT_NMODES_LIG, DEFAULT_LIG_NM_FILE
 from lightdock.mathutil.ellipsoid import MinimumVolumeEllipsoid
@@ -35,8 +36,8 @@ if __name__ == "__main__":
         ligand = read_input_structure(args.ligand_pdb, args.noxt)
         
         # Move structures to origin
-        receptor.move_to_origin()
-        ligand.move_to_origin()
+        rec_translation = receptor.move_to_origin()
+        lig_translation = ligand.move_to_origin()
 
         # Calculate reference points for receptor
         log.info("Calculating reference points for receptor %s..." % args.receptor_pdb)
@@ -63,12 +64,34 @@ if __name__ == "__main__":
             calculate_anm(receptor, args.anm_rec, DEFAULT_REC_NM_FILE)
             calculate_anm(ligand, args.anm_lig, DEFAULT_LIG_NM_FILE)
 
+        # Parse restraints if any:
+        if args.restraints:
+            log.info("Reading restraints from %s" % args.restraints)
+            restraints = parse_restraints_file(args.restraints)
+            # Check if restraints have been defined for the ligand, but not to the receptor
+            if len(restraints['ligand']) and not len(restrains['receptor']):
+                raise LightDockError("Restraints defined for ligand, but not receptor. Try switching structures.")
+
+            if not len(restraints['receptor']) and not len(restraints['ligand']):
+                raise LightDockError("Restraints file specified, but not a single restraint found")
+
+            # Check if restraints correspond with real residues
+            receptor_restraints = get_restraints(receptor, restraints['receptor'])
+            args.receptor_restraints = restraints['receptor']
+            ligand_restraints = get_restraints(ligand, restraints['ligand'])
+            args.ligand_restraints = restraints['ligand']
+
         # Calculate surface points (swarm centers) over receptor structure
         starting_points_files = calculate_starting_positions(receptor, ligand, 
                                                              args.swarms, args.glowworms, 
-                                                             args.starting_points_seed, 
+                                                             args.starting_points_seed,
+                                                             receptor_restraints, ligand_restraints, 
+                                                             rec_translation, lig_translation,
                                                              args.ftdock_file, args.use_anm, args.anm_seed,
                                                              args.anm_rec, args.anm_lig)
+        if len(starting_points_files) != args.swarms:
+            args.swarms = len(starting_points_files)
+            log.info('Number of swarms is %d after applying restraints' % args.swarms)
 
         # Create simulation folders
         prepare_results_environment(args.swarms)

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@ If you execute `lightdock_setup` several options will appear:
 ```bash
 usage: lightdock_setup [-h] [--seed_points STARTING_POINTS_SEED]
                        [-ft ftdock_file] [--noxt] [-anm] [--seed_anm ANM_SEED]
-                       [-anm_rec ANM_REC] [-anm_lig ANM_LIG]
+                       [-anm_rec ANM_REC] [-anm_lig ANM_LIG] [-rst restraints]
                        receptor_pdb_file ligand_pdb_file swarms glowworms
 lightdock_setup: error: too few arguments
 
@@ -85,6 +85,7 @@ Below there is a description of the rest of accepted paramenters of `lightdock_s
 - **--seed_anm** *ANM_SEED*: An integer can be specified as the seed used in the random number generator of ANM normal modes extents. 
 - **--anm_rec** *ANM_REC*: The number of non-trivial normal modes calculated for the recepetor in the ANM mode.
 - **--anm_lig** *ANM_LIG*: The number of non-trivial normal modes calculated for the ligand in the ANM mode.
+- **-rst** *restraints_file*: If `restraints_file` is provided, distance restraints on the receptor surface will be calculated to provided residues. See `2.2. Restraints` section for more information.
 
 ### 2.1. Results of the setup
 
@@ -101,7 +102,22 @@ After the execution of `lightdock_setup` script, several files and directories w
 - `*.xyz.npy`: Two files with this extension, one for the receptor and one for the ligand, which contains information about the minimum ellipsoid containing each of the structures in NumPy format.
 - `lightdock_rec.nm.npy`and `lightdock_lig.nm.npy`: If ANM is enabled, two files are created containing the normal modes information calculated by the ProDy library.
 
-### 2.2. Tips and tricks
+### 2.2. Distance restraints (Experimental)
+
+In version `0.5.1`, distance restraints on the receptor surface have been implemented. This new feature works in the following way:
+
+From a `restraints_file` file containing the following information:
+
+```
+R A.SER.150 
+R A.TYR.151
+```
+
+Where `R` means for `Receptor` (at the moment only residue restraints on the receptor are accepted) and then the rest of the line is a residue identifier in the format `Chain.Residue_Name.Residue_Number` in the original PDB file numeration.
+
+For each of these residues, only the closest swarms are considered during `lightdock_setup`. At the moment, only the **10 closest swarms** for each residue are considered. If some of the swarms overlap, then only one copy of that swarm is used.
+
+### 2.3. Tips and tricks
 
 - As a general rule of thumb, the receptor structure is the bigger molecule and the ligand the smaller. With bigger and smaller, the metric used is the longest diameter of the minimum ellipsoid containing the molecule. A script called `lgd_calculate_diameter.py` can be found in `$LIGHTDOCK_HOME/bin/support` path in order to calculate an approximation of that metric.
 

--- a/lightdock/prep/simulation.py
+++ b/lightdock/prep/simulation.py
@@ -244,7 +244,6 @@ def get_restraints(structure, restraints):
     for restraint in restraints:
         chain_id, residue_name, residue_number = restraint.split('.')
         residue = structure.get_residue(chain_id, residue_name, residue_number)
-        residue
         if not residue:
             raise LightDockError("Restraint %s not found in structure" % restraint)
         else:

--- a/lightdock/structure/complex.py
+++ b/lightdock/structure/complex.py
@@ -108,6 +108,15 @@ class Complex(object):
         """Moves the structure to the origin of coordinates"""
         translation = [-1*c for c in self.center_of_coordinates()]
         self.translate(translation)
+        return translation
+
+    def get_residue(self, chain_id, residue_name, residue_number):
+        for chain in self.chains:
+            if chain_id == chain.cid:
+                for residue in chain.residues:
+                    if residue.name == residue_name and int(residue.number) == int(residue_number):
+                        return residue
+        return None
 
     def __getitem__(self, item):
         return self.atom_coordinates[item]

--- a/lightdock/structure/residue.py
+++ b/lightdock/structure/residue.py
@@ -85,6 +85,10 @@ class Residue(object):
                 return atom
         return None
 
+    def get_calpha(self):
+        """Get the Calpha atom"""
+        return self.get_atom('CA')
+
     def get_non_hydrogen_atoms(self):
         return [atom for atom in self.atoms if not atom.is_hydrogen()]
 

--- a/lightdock/util/parser.py
+++ b/lightdock/util/parser.py
@@ -97,6 +97,10 @@ class SetupCommandLineParser(object):
         parser.add_argument("-anm_lig", "--anm_lig", help="Number of ANM modes for ligand", 
                             type=SetupCommandLineParser.valid_integer_number,
                             dest="anm_lig", default=DEFAULT_NMODES_LIG)
+        # Restraints file
+        parser.add_argument("-rst", "--rst", help="Restraints file", 
+                            dest="restraints", type=CommandLineParser.valid_file,
+                            metavar="restraints", default=None)
 
         self.args = parser.parse_args()
 

--- a/lightdock/version.py
+++ b/lightdock/version.py
@@ -1,3 +1,3 @@
 """Framework version"""
 
-CURRENT_VERSION = "0.5.0"
+CURRENT_VERSION = "0.5.1"


### PR DESCRIPTION
LightDock now accepts residues on the receptor as restraints for the docking. This feature has been implemented as a pre-filter of the closest swarms generated for the docking over the receptor surface.